### PR TITLE
Replace getwd() with here()

### DIFF
--- a/R/1_programming/lessonPart0.Rmd
+++ b/R/1_programming/lessonPart0.Rmd
@@ -128,10 +128,10 @@ Before we actually get started with messing in R, we need to understand how R in
 
 ## The working directory
 
-Every R session has a _working directory,_ or a "home base" folder. Essentially, this is the folder that R is "in". R is not actually installed in this folder, mind you! The working directory is the first folder where R looks for raw data files to load in. You can find out what folder is your working directory using the `getwd()` command as below.
+Every R session has a _working directory,_ or a "home base" folder. Essentially, this is the folder that R is "in". R is not actually installed in this folder, mind you! The working directory is the first folder where R looks for raw data files to load in. You can find out what folder is your working directory using the `here()` command as below.
 
 ```{r explain working directories}
-getwd()
+here()
 ```
 
 If you run this command on your own computer, you'll get a different folder. And that's okay! Our folder structures on our computers are all different.


### PR DESCRIPTION
Keeping the spirit of the lesson intact, but use `here()` instead of `getwd()` to show the working directory. R Markdowns natively treat _the folder that the Rmd is in_ as the working directory, not necessarily the home directory that the .Rproj file lives in. If one keeps one's Rmds in one folder, and and one's data files in another folder, this causes many many many path headaches. Best practice seems to be to use `here()` and have the project home be the working directory for all needs. Resolves #65 .