### PR TITLE
Updating meeting timing

### DIFF
--- a/content/_index.Rmd
+++ b/content/_index.Rmd
@@ -29,7 +29,7 @@ During the Spring 2021 semester, the [graduate methods support advisors](/who/) 
 
 ---
 
-Our next workshop, *Creating Websites in Github and R*, is scheduled for January 27th, 2021, at 4 pm. For more information, visit the [Meetings](/meetings/) page.
+Our next workshop, *Creating Websites in Github and R*, is scheduled for February 10th, 2021, at 4 pm. For more information, visit the [Meetings](/meetings/) page.
 
 ## Annual Scientific Computing Workshop
 

--- a/content/_index.html
+++ b/content/_index.html
@@ -28,7 +28,7 @@ output:
 <div id="ongoing-meetings-and-workshops" class="section level2">
 <h2>Ongoing Meetings and Workshops</h2>
 <hr />
-<p>Our next workshop, <em>Creating Websites in Github and R</em>, is scheduled for January 27th, 2021, at 4 pm. For more information, visit the <a href="/meetings/">Meetings</a> page.</p>
+<p>Our next workshop, <em>Creating Websites in Github and R</em>, is scheduled for February 10th, 2021, at 4 pm. For more information, visit the <a href="/meetings/">Meetings</a> page.</p>
 </div>
 <div id="annual-scientific-computing-workshop" class="section level2">
 <h2>Annual Scientific Computing Workshop</h2>

--- a/content/meetings.Rmd
+++ b/content/meetings.Rmd
@@ -18,10 +18,24 @@ Come and learn with us at one of our meetings! Topics span various early-interme
 
 ---
 
-**Wednesday, January 27th, 2021 at 4:00pm:** Workshop (Creating a Website with Github and R)
+### Workshop: Creating a Website with Github and R
+
+**Date:** Wednesday, February 10th, 2021 at 4:00pm
+
+**Instructor:** Emily Nakkawita
+
+### Workshop: Confidence Intervals
+
+**Date:** Wednesday, March 17th, 2021 at 4:00pm
+
+**Instructors:** Monica Thieu and Paul Bloom
 
 ## Past
 
 ---
 
-**Wednesday, November 18th, 2020 at 4:00pm:** Round-Table Discussion (Online Experiments)
+### Round-Table Discussion: Online Experiments
+
+**Date:** Wednesday, November 18th, 2020 at 4:00pm
+
+**Moderators:** Hannah Tarder-Stoll and Emily Nakkawita

--- a/content/meetings.html
+++ b/content/meetings.html
@@ -17,11 +17,24 @@ output:
 <div id="upcoming" class="section level2">
 <h2>Upcoming</h2>
 <hr />
-<p><strong>Wednesday, January 27th, 2021 at 4:00pm:</strong> Workshop (Creating a Website with Github and R)</p>
+<div id="workshop-creating-a-website-with-github-and-r" class="section level3">
+<h3>Workshop: Creating a Website with Github and R</h3>
+<p><strong>Date:</strong> Wednesday, February 10th, 2021 at 4:00pm</p>
+<p><strong>Instructor:</strong> Emily Nakkawita</p>
+</div>
+<div id="workshop-confidence-intervals" class="section level3">
+<h3>Workshop: Confidence Intervals</h3>
+<p><strong>Date:</strong> Wednesday, March 17th, 2021 at 4:00pm</p>
+<p><strong>Instructors:</strong> Monica Thieu and Paul Bloom</p>
+</div>
 </div>
 <div id="past" class="section level2">
 <h2>Past</h2>
 <hr />
-<p><strong>Wednesday, November 18th, 2020 at 4:00pm:</strong> Round-Table Discussion (Online Experiments)</p>
+<div id="round-table-discussion-online-experiments" class="section level3">
+<h3>Round-Table Discussion: Online Experiments</h3>
+<p><strong>Date:</strong> Wednesday, November 18th, 2020 at 4:00pm</p>
+<p><strong>Moderators:</strong> Hannah Tarder-Stoll and Emily Nakkawita</p>
+</div>
 </div>
 </div>

--- a/public/index.html
+++ b/public/index.html
@@ -491,7 +491,7 @@ button:focus {
 <div id="ongoing-meetings-and-workshops" class="section level2">
 <h2>Ongoing Meetings and Workshops</h2>
 <hr />
-<p>Our next workshop, <em>Creating Websites in Github and R</em>, is scheduled for January 27th, 2021, at 4 pm. For more information, visit the <a href="./meetings/">Meetings</a> page.</p>
+<p>Our next workshop, <em>Creating Websites in Github and R</em>, is scheduled for February 10th, 2021, at 4 pm. For more information, visit the <a href="./meetings/">Meetings</a> page.</p>
 </div>
 <div id="annual-scientific-computing-workshop" class="section level2">
 <h2>Annual Scientific Computing Workshop</h2>

--- a/public/index.xml
+++ b/public/index.xml
@@ -237,10 +237,12 @@ You are free:
       <pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
       
       <guid>/meetings/</guid>
-      <description>   Meetings Come and learn with us at one of our meetings! Topics span various early-intermediate to advanced strategies for asking psychological research questions using scientific computing tools.
-Upcoming Wednesday, January 27th, 2021 at 4:00pm: Workshop (Creating a Website with Github and R)
- Past Wednesday, November 18th, 2020 at 4:00pm: Round-Table Discussion (Online Experiments)
-  </description>
+      <description>Meetings Come and learn with us at one of our meetings! Topics span various early-intermediate to advanced strategies for asking psychological research questions using scientific computing tools.
+Upcoming Workshop: Creating a Website with Github and R Date: Wednesday, February 10th, 2021 at 4:00pm
+Instructor: Emily Nakkawita
+ Workshop: Confidence Intervals Date: Wednesday, March 17th, 2021 at 4:00pm
+Instructors: Monica Thieu and Paul Bloom
+  Past Round-Table Discussion: Online Experiments Date: Wednesday, November 18th, 2020 at 4:00pm</description>
     </item>
     
     <item>

--- a/public/meetings/index.html
+++ b/public/meetings/index.html
@@ -475,12 +475,25 @@ button:focus {
 <div id="upcoming" class="section level2">
 <h2>Upcoming</h2>
 <hr />
-<p><strong>Wednesday, January 27th, 2021 at 4:00pm:</strong> Workshop (Creating a Website with Github and R)</p>
+<div id="workshop-creating-a-website-with-github-and-r" class="section level3">
+<h3>Workshop: Creating a Website with Github and R</h3>
+<p><strong>Date:</strong> Wednesday, February 10th, 2021 at 4:00pm</p>
+<p><strong>Instructor:</strong> Emily Nakkawita</p>
+</div>
+<div id="workshop-confidence-intervals" class="section level3">
+<h3>Workshop: Confidence Intervals</h3>
+<p><strong>Date:</strong> Wednesday, March 17th, 2021 at 4:00pm</p>
+<p><strong>Instructors:</strong> Monica Thieu and Paul Bloom</p>
+</div>
 </div>
 <div id="past" class="section level2">
 <h2>Past</h2>
 <hr />
-<p><strong>Wednesday, November 18th, 2020 at 4:00pm:</strong> Round-Table Discussion (Online Experiments)</p>
+<div id="round-table-discussion-online-experiments" class="section level3">
+<h3>Round-Table Discussion: Online Experiments</h3>
+<p><strong>Date:</strong> Wednesday, November 18th, 2020 at 4:00pm</p>
+<p><strong>Moderators:</strong> Hannah Tarder-Stoll and Emily Nakkawita</p>
+</div>
 </div>
 </div>
 


### PR DESCRIPTION
Updated the Building a Website meeting timing on the homepage and Meetings page, added the new Confidence Intervals workshop to the Meetings page, and tweaked the Meetings page formatting so the topics are more prominently featured.

@monicathieu, if you'd like to use a more specific / snazzy name for your workshop with Paul, please feel free to revise it as you review!